### PR TITLE
fix: when student is ignored prohibit adding or changing their grade …

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -241,8 +241,10 @@ class DataStorage:
             stmt = (
                 select(User.username, Attendance)
                 .join(User, Attendance.user_id == User.id)
+                .join(UserCourseAssociation, UserCourseAssociation.user_id == User.id)
                 .where(Attendance.lesson_id == course.lessons[-1].id)
-                .where(User.username.in_(candidates))
+                .where(User.username.in_(candidates)
+                .where(UserCourseAssociation.course_id == course.id))
             )
 
             result = await session.execute(stmt)

--- a/src/data.py
+++ b/src/data.py
@@ -243,8 +243,8 @@ class DataStorage:
                 .join(User, Attendance.user_id == User.id)
                 .join(UserCourseAssociation, UserCourseAssociation.user_id == User.id)
                 .where(Attendance.lesson_id == course.lessons[-1].id)
-                .where(User.username.in_(candidates)
-                .where(UserCourseAssociation.course_id == course.id))
+                .where(User.username.in_(candidates))
+                .where(UserCourseAssociation.course_id == course.id)
             )
 
             result = await session.execute(stmt)


### PR DESCRIPTION
There was a bug when student was ignored, teacher could still grade him. Even though the student didn’t appear in the stats. Their grade would change reflecting their performance if they are registered after being ignored.